### PR TITLE
feat: add support for loading old sessions (data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ Each request is parsed to extract: model name, system prompts, tool definitions,
 
 ## Data
 
-Captured requests are kept in memory (last 100) and persisted to `data/state.jsonl` across restarts. Each session is also logged as a separate `.lhar` file in `data/`. Use the Reset button in the UI to clear everything.
+Captured requests are kept in memory (last 10 sessions) and persisted to `data/state.jsonl` across restarts. Each session is also logged as a separate `.lhar` file in `data/`. Use the Reset button in the UI to clear everything.
+
+Evicted or old sessions remain on disk as `.lhar` files. The sidebar shows an **Archived** section where you can browse and reload them. To include `.lhar` files from other directories (e.g. a previous `npx` install), set:
+
+```bash
+CONTEXT_LENS_ARCHIVE_DIRS=/path/to/old/data,/another/path context-lens wrap claude "prompt"
+```
 
 ## License
 

--- a/public/index.html
+++ b/public/index.html
@@ -394,6 +394,43 @@ body::after {
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 
+/* Archived sessions */
+.archived-section {
+  padding: 12px 14px 6px;
+  font-size: 10px; color: var(--text-dim);
+  text-transform: uppercase; letter-spacing: 0.1em;
+  font-weight: 600;
+  border-top: 1px solid var(--border-mid);
+  border-bottom: 1px solid var(--border-dim);
+  cursor: pointer; user-select: none;
+  display: flex; align-items: center; gap: 6px;
+}
+.archived-section:hover { color: var(--text-secondary); }
+.archived-toggle { font-size: 8px; transition: transform 0.2s; }
+.archived-toggle.open { transform: rotate(90deg); }
+.archived-item {
+  padding: 8px 14px;
+  cursor: pointer;
+  border-left: 2px solid transparent;
+  transition: background 0.15s, border-color 0.15s;
+  opacity: 0.7;
+}
+.archived-item:hover { background: var(--bg-surface); opacity: 1; }
+.archived-meta {
+  display: flex; gap: 10px; margin-top: 4px; padding-left: 14px;
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-dim);
+}
+.archived-load {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10px; padding: 2px 8px; border-radius: 3px;
+  background: rgba(91, 156, 245, 0.1); color: var(--accent-blue);
+  border: 1px solid rgba(91, 156, 245, 0.2);
+  cursor: pointer; opacity: 0; transition: opacity 0.15s;
+}
+.archived-item:hover .archived-load { opacity: 1; }
+.archived-load:hover { background: rgba(91, 156, 245, 0.2); }
+
 /* Model color helpers */
 .model-opus { color: #fb923c; }
 .model-sonnet { color: #60a5fa; }
@@ -825,6 +862,8 @@ body::after {
   let turnDetailMode = 'calls'; // 'calls' or 'diff'
   let expandedCategories = new Set();
   let expandedAgentGroups = new Set();
+  let archivedSessions = [];
+  let archivedExpanded = false;
   let turnCallsExpanded = false;
   let sourceFilter = '';
 
@@ -1124,6 +1163,33 @@ body::after {
     html += '<div><span>Total cost</span><span style="color:var(--accent-green);">' + fmtCost(totalCost) + '</span></div>';
     html += '</div>';
 
+    // Archived sessions section
+    if (archivedSessions.length > 0) {
+      html += '<div class="archived-section" id="archived-toggle">';
+      html += '<span class="archived-toggle' + (archivedExpanded ? ' open' : '') + '">&#9654;</span>';
+      html += 'Archived (' + archivedSessions.length + ')';
+      html += '</div>';
+      if (archivedExpanded) {
+        archivedSessions.forEach(function(a) {
+          var label = a.label || ('Session ' + a.id.slice(0, 8));
+          var dateStr = a.startedAt ? new Date(a.startedAt).toLocaleDateString([], {month:'short', day:'numeric'}) : '';
+          html += '<div class="archived-item" data-archived-file="' + esc(a.filename) + '" data-archived-dir="' + esc(a.dir || '') + '">';
+          html += '<div class="session-head">';
+          html += '<span class="badge ' + sourceBadgeClass(a.source) + '">' + esc(a.source || '?') + '</span>';
+          html += '<span style="font-family:var(--font-mono);font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-secondary);">' + esc(shortModel(a.model)) + '</span>';
+          html += '<span class="archived-load" data-load-file="' + esc(a.filename) + '" data-load-dir="' + esc(a.dir || '') + '">Load</span>';
+          html += '</div>';
+          html += '<div class="archived-meta">';
+          html += '<span>' + esc(label) + '</span>';
+          html += '<span>' + a.entryCount + ' turns</span>';
+          if (dateStr) html += '<span>' + esc(dateStr) + '</span>';
+          html += '</div>';
+          if (a.workingDirectory) html += '<div class="working-dir">' + esc(a.workingDirectory) + '</div>';
+          html += '</div>';
+        });
+      }
+    }
+
     sb.innerHTML = html;
 
     sb.querySelectorAll('.session-item').forEach(function(el) {
@@ -1165,7 +1231,52 @@ body::after {
           }
           expandedSessions.delete(sid);
           fetchAndRender();
+          fetchArchivedSessions();
         });
+      });
+    });
+
+    // Archived section toggle
+    var archToggle = sb.querySelector('#archived-toggle');
+    if (archToggle) {
+      archToggle.addEventListener('click', function() {
+        archivedExpanded = !archivedExpanded;
+        renderSidebar();
+      });
+    }
+
+    // Archived load buttons
+    sb.querySelectorAll('.archived-load').forEach(function(el) {
+      el.addEventListener('click', function(ev) {
+        ev.stopPropagation();
+        var filename = el.getAttribute('data-load-file');
+        var dir = el.getAttribute('data-load-dir');
+        el.textContent = '...';
+        fetch('/api/sessions/load', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ filename: filename, dir: dir || undefined }),
+        }).then(function(r) { return r.json(); }).then(function(data) {
+          if (data.conversationId) {
+            selectedSessionId = data.conversationId;
+            selectedTurnIndex = -1;
+            expandedSessions.add(data.conversationId);
+            currentRevision = -1; // Force re-fetch
+            fetchAndRender();
+            fetchArchivedSessions();
+          }
+        }).catch(function(err) {
+          console.error('Load error:', err);
+          el.textContent = 'Error';
+        });
+      });
+    });
+
+    // Archived item click (same as load)
+    sb.querySelectorAll('.archived-item').forEach(function(el) {
+      el.addEventListener('click', function() {
+        var loadBtn = el.querySelector('.archived-load');
+        if (loadBtn) loadBtn.click();
       });
     });
 
@@ -2237,6 +2348,20 @@ body::after {
     });
   });
 
+  // --- Archived Sessions ---
+  function fetchArchivedSessions() {
+    fetch('/api/sessions/archived').then(function(r) { return r.json(); }).then(function(data) {
+      if (Array.isArray(data)) {
+        var changed = JSON.stringify(data.map(function(a) { return a.id; }))
+          !== JSON.stringify(archivedSessions.map(function(a) { return a.id; }));
+        archivedSessions = data;
+        if (changed) renderSidebar();
+      }
+    }).catch(function(err) {
+      console.error('Archived fetch error:', err);
+    });
+  }
+
   // --- Polling ---
   function fetchAndRender() {
     // Flash poll indicator
@@ -2797,6 +2922,7 @@ body::after {
   }
 
   fetchAndRender();
+  fetchArchivedSessions();
   setInterval(fetchAndRender, 2000);
 })();
 </script>

--- a/schema/lhar.schema.json
+++ b/schema/lhar.schema.json
@@ -58,7 +58,9 @@
         "trace_id": { "type": "string" },
         "started_at": { "type": "string" },
         "tool": { "type": "string" },
-        "model": { "type": "string" }
+        "model": { "type": "string" },
+        "label": { "type": "string" },
+        "working_directory": { "type": "string" }
       },
       "required": ["type", "trace_id", "started_at", "tool", "model"],
       "additionalProperties": false

--- a/src/lhar-types.generated.ts
+++ b/src/lhar-types.generated.ts
@@ -59,6 +59,8 @@ export interface LharSessionLine {
   started_at: string;
   tool: string;
   model: string;
+  label?: string;
+  working_directory?: string;
 }
 /**
  * This interface was referenced by `LHARLLMHTTPArchiveFormat`'s JSON-Schema


### PR DESCRIPTION
This PR adds support for browsing and reloading archived sessions from `.lhar` files, including those from previous installations or external directories.

It introduces a new "Archived" section in the sidebar UI, allows users to reload archived sessions into memory, and provides backend endpoints and logic to manage archived session discovery and loading.

Additionally, it extends the LHAR schema to preserve more metadata about sessions.

<img width="356" height="151" alt="SCR-20260210-nldg" src="https://github.com/user-attachments/assets/5467b6a5-de28-4f55-9b50-1ba54fdbc6b5" />

---

## Copilot generated summary

**New Archived Sessions Feature**

* Adds an "Archived" section to the sidebar UI, displaying evicted or old sessions found as `.lhar` files on disk, with the ability to browse, view metadata, and reload sessions into active memory via the UI. [[1]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR397-R433) [[2]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR865-R866) [[3]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR1166-R1192) [[4]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR1234-R1282) [[5]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR2351-R2364) [[6]](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdR2925)

**Backend and API Enhancements**

* Implements new backend endpoints:  
  - `GET /api/sessions/archived` to list available archived sessions from all configured archive directories  
  - `POST /api/sessions/load` to load a selected archived session into memory, reconstructing the conversation and its entries [[1]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R56-R71) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R692-R847)
* Supports specifying additional archive directories via the `CONTEXT_LENS_ARCHIVE_DIRS` environment variable, making it easy to import sessions from other locations. [[1]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R56-R71) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R932-R934)
* Adds conversion logic to reconstruct in-memory session entries from LHAR records when reloading archived sessions.

**Schema and Type Improvements**

* Extends the LHAR session schema and types to include optional `label` and `working_directory` fields, preserving more metadata for each session. [[1]](diffhunk://#diff-251ec692b847dfe9a2d9456af2da008110bffe3f23bbdd4a96cdba239831fed5L61-R63) [[2]](diffhunk://#diff-7929ed3de955e918897d4f563e9d6043fcb2563a78a12bbe21eee455e49f24a6R62-R63) [[3]](diffhunk://#diff-02b1aab40dce19bef3a3f63c6142083280e0877cb3a918678c6762b57fa4182bL485-R565)

**Documentation Updates**

* Updates the `README.md` to document the new archived sessions feature and the use of the `CONTEXT_LENS_ARCHIVE_DIRS` environment variable for importing sessions.