### PR TITLE
fix(docker): ignore scripts in prod install to fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV NODE_ENV=production
 ENV CONTEXT_LENS_NO_UPDATE_CHECK=1
 
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --prod
+RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/ui/dist ./ui/dist


### PR DESCRIPTION
The `@contextio` packages run a git-dependent prepare script during install. The slim runtime image has no git, causing the Docker publish to fail for v0.6.0. Adding `--ignore-scripts` to the prod `pnpm install` step fixes this.