### PR TITLE
fix(docker): ignore-scripts in build stage pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY . .
 


### PR DESCRIPTION
Same git-not-found issue in the build stage. --ignore-scripts only suppresses dependency lifecycle scripts; our explicit RUN build commands are unaffected.