### PR TITLE
fix(docker): bust build cache to pick up --ignore-scripts fix

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           context: .
           push: true
+          no-cache: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max


### PR DESCRIPTION
The Docker build cache is keyed on package.json/pnpm-lock.yaml. Since those haven't changed, the old layer (without --ignore-scripts) is being reused. Touching pnpm-lock.yaml forces a cache miss.