### PR TITLE
fix(cli): use cmd /c start on Windows to open browser in MSYS2/Git Bash

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -916,18 +916,29 @@ if (parsedArgs.commandName === "analyze") {
 
   // Open browser (cross-platform)
   function openBrowser(url: string): void {
-    const cmd =
-      platform() === "darwin"
-        ? "open"
-        : platform() === "win32"
-          ? "start"
-          : "xdg-open";
+    let cmd: string;
+    let args: string[];
 
-    const browserProcess = spawn(cmd, [url], {
+    if (platform() === "darwin") {
+      cmd = "open";
+      args = [url];
+    } else if (platform() === "win32") {
+      // `start` is a cmd.exe built-in, not a standalone executable.
+      // Using `cmd /c start` works in all Windows shells including MSYS2/Git Bash.
+      cmd = "cmd";
+      args = ["/c", "start", url];
+    } else {
+      cmd = "xdg-open";
+      args = [url];
+    }
+
+    const browserProcess = spawn(cmd, args, {
       stdio: "ignore",
       detached: true,
     });
 
+    // Non-fatal: if the browser can't be opened, just continue.
+    browserProcess.on("error", () => {});
     browserProcess.unref(); // Don't wait for browser to close
   }
 


### PR DESCRIPTION
Fixes #33

## Problem

On Windows, `start` is a `cmd.exe` built-in and not a standalone executable. In MSYS2/Git Bash there is no `start.exe`, so spawning it directly causes a crash:

```
Error: spawn start ENOENT
```

## Fix

- Use `cmd /c start <url>` on Windows instead of bare `start`. This works across all Windows shells: cmd.exe, PowerShell, and MSYS2/Git Bash.
- Add a `.on('error', () => {})` handler on the child process so any spawn failure is silently ignored rather than crashing the main process. This covers the reporter's request: "if it can't open, just continue."