### PR TITLE
fix: parse OpenAI chat-completions tool_calls and role=tool messages

### DIFF
--- a/src/core/parse.ts
+++ b/src/core/parse.ts
@@ -368,15 +368,64 @@ export function parseContextInfo(
           info.systemPrompts.push({ content: msg.content });
           info.systemTokens += estimateTokens(msg.content, model);
         } else {
+          const contentBlocks: ContentBlock[] = [];
+          let contentStr: string;
+          let tokenTarget: any = msg.content;
+
+          // Handle text content (string, array, or null)
+          if (typeof msg.content === "string") {
+            contentStr = msg.content;
+            contentBlocks.push({ type: "text", text: msg.content });
+          } else if (Array.isArray(msg.content)) {
+            contentStr = msg.content.map((b: any) => b.text || "").join("\n");
+            for (const part of msg.content) {
+              if (part.type === "text")
+                contentBlocks.push({ type: "text", text: part.text || "" });
+            }
+          } else {
+            contentStr = "";
+          }
+
+          // Handle tool_calls on assistant messages
+          if (msg.tool_calls && Array.isArray(msg.tool_calls)) {
+            for (const tc of msg.tool_calls) {
+              const fn = tc.function || {};
+              let parsedArgs: Record<string, any> = {};
+              if (typeof fn.arguments === "string" && fn.arguments.length > 0) {
+                try {
+                  parsedArgs = JSON.parse(fn.arguments);
+                } catch {
+                  /* keep empty */
+                }
+              }
+              contentBlocks.push({
+                type: "tool_use",
+                id: tc.id || "",
+                name: fn.name || "unknown",
+                input: parsedArgs,
+              });
+            }
+            tokenTarget = { content: msg.content, tool_calls: msg.tool_calls };
+          }
+
+          // Handle role="tool" messages
+          if (msg.role === "tool" && msg.tool_call_id) {
+            contentBlocks.length = 0;
+            contentBlocks.push({
+              type: "tool_result",
+              tool_use_id: msg.tool_call_id,
+              content: contentStr,
+            });
+          }
+
+          const tokens = estimateTokens(tokenTarget, model);
           info.messages.push({
             role: msg.role,
-            content:
-              typeof msg.content === "string"
-                ? msg.content
-                : JSON.stringify(msg.content),
-            tokens: estimateTokens(msg.content, model),
+            content: contentStr || JSON.stringify(msg.content),
+            contentBlocks: contentBlocks.length > 0 ? contentBlocks : null,
+            tokens,
           });
-          info.messagesTokens += estimateTokens(msg.content, model);
+          info.messagesTokens += tokens;
         }
       });
     }

--- a/src/lhar/composition.ts
+++ b/src/lhar/composition.ts
@@ -126,6 +126,21 @@ function classifyMessage(
     return;
   }
 
+  // Tool result messages (OpenAI chat-completions role="tool")
+  if (role === "tool") {
+    add("tool_results", estimateTokens(content, model));
+    return;
+  }
+
+  // Assistant messages with tool_calls (OpenAI chat-completions)
+  if (role === "assistant" && msg.tool_calls && Array.isArray(msg.tool_calls)) {
+    add("tool_calls", estimateTokens(msg.tool_calls, model));
+    if (typeof content === "string" && content.length > 0) {
+      add("assistant_text", estimateTokens(content, model));
+    }
+    return;
+  }
+
   // String content
   if (typeof content === "string") {
     if (content.includes("<system-reminder>")) {

--- a/test/context-parse.test.ts
+++ b/test/context-parse.test.ts
@@ -7,6 +7,7 @@ import {
   claudeSession,
   codexResponses,
   openaiChat,
+  openaiChatTools,
 } from "./helpers/fixtures.js";
 
 describe("parseContextInfo", () => {
@@ -218,6 +219,104 @@ describe("parseContextInfo", () => {
       const info = parseContextInfo("openai", body, "chat-completions");
       assert.equal(info.tools.length, 1);
       assert.equal((info.tools[0] as any).name, "search");
+    });
+
+    it("parses assistant tool_calls into contentBlocks", () => {
+      const info = parseContextInfo(
+        "openai",
+        openaiChatTools,
+        "chat-completions",
+      );
+      // msg[2] in fixture: assistant with content:null + tool_calls
+      const assistantMsg = info.messages.find(
+        (m) =>
+          m.role === "assistant" &&
+          m.contentBlocks?.some((b: any) => b.name === "read_file"),
+      );
+      assert.ok(assistantMsg, "should find assistant message with read_file");
+      assert.ok(assistantMsg!.contentBlocks, "should have contentBlocks");
+      const toolUse = assistantMsg!.contentBlocks![0] as any;
+      assert.equal(toolUse.type, "tool_use");
+      assert.equal(toolUse.id, "call_abc123");
+      assert.equal(toolUse.name, "read_file");
+      assert.deepEqual(toolUse.input, { path: "/src/auth.js" });
+      assert.ok(assistantMsg!.tokens > 0, "tokens should be > 0");
+    });
+
+    it("parses role=tool messages as tool results with contentBlocks", () => {
+      const info = parseContextInfo(
+        "openai",
+        openaiChatTools,
+        "chat-completions",
+      );
+      // msg[3] in fixture: role=tool with tool_call_id
+      const toolMsg = info.messages.find(
+        (m) =>
+          m.role === "tool" &&
+          m.contentBlocks?.some(
+            (b: any) => b.tool_use_id === "call_abc123",
+          ),
+      );
+      assert.ok(toolMsg, "should find tool result message");
+      assert.ok(toolMsg!.contentBlocks, "should have contentBlocks");
+      const toolResult = toolMsg!.contentBlocks![0] as any;
+      assert.equal(toolResult.type, "tool_result");
+      assert.equal(toolResult.tool_use_id, "call_abc123");
+      assert.ok(
+        toolResult.content.includes("express-auth"),
+        "should contain tool output",
+      );
+      assert.ok(toolMsg!.tokens > 0, "tokens should be > 0");
+    });
+
+    it("handles assistant with both text content and tool_calls", () => {
+      const info = parseContextInfo(
+        "openai",
+        openaiChatTools,
+        "chat-completions",
+      );
+      // msg[4] in fixture: assistant with text + tool_calls
+      const mixedMsg = info.messages.find(
+        (m) =>
+          m.role === "assistant" &&
+          m.contentBlocks?.some((b: any) => b.name === "write_file"),
+      );
+      assert.ok(mixedMsg, "should find assistant message with write_file");
+      const blocks = mixedMsg!.contentBlocks!;
+      assert.ok(blocks.length >= 2, "should have text + tool_use blocks");
+      const textBlock = blocks.find((b: any) => b.type === "text") as any;
+      assert.ok(textBlock, "should have a text block");
+      assert.ok(textBlock.text.includes("I found the issue"));
+      const toolBlock = blocks.find((b: any) => b.type === "tool_use") as any;
+      assert.ok(toolBlock, "should have a tool_use block");
+      assert.equal(toolBlock.name, "write_file");
+      assert.ok(mixedMsg!.tokens > 0, "tokens should be > 0");
+    });
+
+    it("content:null assistant messages have non-zero tokens when tool_calls present", () => {
+      const body = {
+        model: "gpt-4o",
+        messages: [
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "test_fn", arguments: '{"key":"value"}' },
+              },
+            ],
+          },
+        ],
+      };
+      const info = parseContextInfo("openai", body, "chat-completions");
+      assert.ok(info.messagesTokens > 0, "messagesTokens should be > 0");
+      assert.equal(
+        info.totalTokens,
+        info.systemTokens + info.toolsTokens + info.messagesTokens,
+        "totalTokens invariant",
+      );
     });
   });
 

--- a/test/fixtures/openai-chat-tools.json
+++ b/test/fixtures/openai-chat-tools.json
@@ -1,0 +1,82 @@
+{
+  "model": "gpt-4.1",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a helpful coding assistant."
+    },
+    {
+      "role": "user",
+      "content": "Read the auth module and fix the login bug"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "call_abc123",
+          "type": "function",
+          "function": {
+            "name": "read_file",
+            "arguments": "{\"path\":\"/src/auth.js\"}"
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_abc123",
+      "content": "const auth = require('express-auth');\nmodule.exports = { login };"
+    },
+    {
+      "role": "assistant",
+      "content": "I found the issue. The login function is missing error handling. Let me fix it.",
+      "tool_calls": [
+        {
+          "id": "call_def456",
+          "type": "function",
+          "function": {
+            "name": "write_file",
+            "arguments": "{\"path\":\"/src/auth.js\",\"content\":\"const auth = require('express-auth');\\nmodule.exports = { login: (req, res) => { try { auth(req); } catch(e) { res.status(401).send(); } } };\"}"
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_def456",
+      "content": "File written successfully"
+    },
+    {
+      "role": "assistant",
+      "content": "I've fixed the login bug by adding error handling to the auth module."
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "read_file",
+        "description": "Read a file from disk",
+        "parameters": {
+          "type": "object",
+          "properties": { "path": { "type": "string" } }
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "write_file",
+        "description": "Write content to a file",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string" },
+            "content": { "type": "string" }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -16,3 +16,6 @@ export const claudeSession = JSON.parse(
 export const openaiChat = JSON.parse(
   readFileSync(join(fixturesDir, "openai-chat.json"), "utf-8"),
 );
+export const openaiChatTools = JSON.parse(
+  readFileSync(join(fixturesDir, "openai-chat-tools.json"), "utf-8"),
+);

--- a/test/lhar.test.ts
+++ b/test/lhar.test.ts
@@ -387,6 +387,59 @@ describe("analyzeComposition", () => {
       `composition total (${totalCompTokens}) should not be inflated by double-counting`,
     );
   });
+
+  it("classifies chat-completions tool_calls and tool results", () => {
+    const openaiChatTools = JSON.parse(
+      readFileSync(join(fixturesDir, "openai-chat-tools.json"), "utf-8"),
+    );
+    const ci = parseContextInfo(
+      "openai",
+      openaiChatTools,
+      "chat-completions",
+    );
+    const comp = analyzeComposition(ci, openaiChatTools);
+    const categories = comp.map((c) => c.category);
+    assert.ok(
+      categories.includes("tool_calls"),
+      "should have tool_calls",
+    );
+    assert.ok(
+      categories.includes("tool_results"),
+      "should have tool_results",
+    );
+    assert.ok(
+      categories.includes("assistant_text"),
+      "should have assistant_text",
+    );
+    const toolCalls = comp.find((c) => c.category === "tool_calls");
+    assert.ok(toolCalls!.tokens > 0, "tool_calls tokens > 0");
+    const toolResults = comp.find((c) => c.category === "tool_results");
+    assert.ok(toolResults!.tokens > 0, "tool_results tokens > 0");
+    const assistantText = comp.find((c) => c.category === "assistant_text");
+    assert.ok(assistantText!.tokens > 0, "assistant_text tokens > 0");
+  });
+
+  it("role=tool messages are not classified as user_text", () => {
+    const openaiChatTools = JSON.parse(
+      readFileSync(join(fixturesDir, "openai-chat-tools.json"), "utf-8"),
+    );
+    const ci = parseContextInfo(
+      "openai",
+      openaiChatTools,
+      "chat-completions",
+    );
+    const comp = analyzeComposition(ci, openaiChatTools);
+    const userText = comp.find((c) => c.category === "user_text");
+    const toolResults = comp.find((c) => c.category === "tool_results");
+    assert.ok(toolResults, "should have tool_results category");
+    // user_text should only be the single user message, not the tool results
+    if (userText) {
+      assert.ok(
+        userText.tokens < toolResults!.tokens,
+        `user_text (${userText.tokens}) should be less than tool_results (${toolResults!.tokens}) — tool results must not be lumped into user_text`,
+      );
+    }
+  });
 });
 
 // --- normalizeComposition ---


### PR DESCRIPTION
The OpenAI chat-completions parser does not handle the tool-calling message format from the OpenAI spec. This causes missing data for any tool using chat-completions with function calling (GitHub Copilot CLI, direct OpenAI API, etc.):

- `assistant_text` reads as 0 tokens
- `tool_calls` and `tool_results` are absent from the composition breakdown
- Tool result messages are misclassified as `user_text`

This PR fixes three gaps in `parseContextInfo()` and `classifyMessage()` to correctly parse and classify these message types.

1. **`ChatCompletionRequestAssistantMessage`** — `content` is nullable when `tool_calls` is present. The old code stringified `null` to `"null"` and ignored the `tool_calls` array entirely.

2. **`ChatCompletionRequestToolMessage`** — uses `role: "tool"` with a required `tool_call_id`. The old code had no special handling, so these fell through with no `contentBlocks`.

3. **`classifyMessage()`** in the composition analyzer had no branches for either type, so tool results were bucketed as `user_text` and tool calls were invisible.


**Screenshots**

Below is a before and after comparison of the copilot CLI working the same prompt. Its pretty clear in the first image we are missing almost all the data. 

<details><summary><b>Before changes</b></summary>
<img width="1040" height="324" alt="Screenshot_20260401_220938-1" src="https://github.com/user-attachments/assets/f7a5161a-6f40-4f19-b0fe-5f96259c2b2c" />
</details>

<details><summary><b>After changes</b></summary>
<img width="1054" height="535" alt="Screenshot_20260401_221404-1" src="https://github.com/user-attachments/assets/74b0a6f2-9490-4dd6-b22a-e5df6e5b4c42" />
</details>


