### PR TITLE
feat(mitm,cli): support Copilot responses endpoint and enable Node env proxy

### DIFF
--- a/mitm_addon.py
+++ b/mitm_addon.py
@@ -52,6 +52,8 @@ CAPTURE_PATTERNS = [
     # GitHub Copilot chat completions (OpenAI-compatible format)
     ("api.individual.githubcopilot.com", "/chat/completions", "openai", "copilot"),
     ("api.githubcopilot.com", "/chat/completions", "openai", "copilot"),
+    ("api.individual.githubcopilot.com", "/responses", "openai", "copilot"),
+    ("api.githubcopilot.com", "/responses", "openai", "copilot"),
     # OpenAI API — source left as None so detectSource can identify the tool
     # from headers/system prompts (opencode, aider, etc.)
     ("api.openai.com", "/v1/responses", "openai", None),

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@contextio/core": "^0.3.1",
-    "@contextio/proxy": "^0.2.3",
-    "@contextio/redact": "^0.3.0",
+    "@contextio/core": "^0.3.2",
+    "@contextio/proxy": "^0.2.4",
+    "@contextio/redact": "^0.3.1",
     "@hono/node-server": "^1.19.9",
     "hono": "^4.11.9",
     "js-tiktoken": "^1.0.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       '@contextio/core':
+        specifier: ^0.3.2
+        version: 0.3.2
+      '@contextio/proxy':
+        specifier: ^0.2.4
+        version: 0.2.4
+      '@contextio/redact':
         specifier: ^0.3.1
         version: 0.3.1
-      '@contextio/proxy':
-        specifier: ^0.2.3
-        version: 0.2.3
-      '@contextio/redact':
-        specifier: ^0.3.0
-        version: 0.3.0
       '@hono/node-server':
         specifier: ^1.19.9
         version: 1.19.9(hono@4.11.9)
@@ -105,18 +105,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@contextio/core@0.3.0':
-    resolution: {integrity: sha512-8bjIu4dw5f/UqO1ZUMmxBcdWN6byGa06tcY0oSbj6Mr/pK1Tw/LyZu8lnlY57zI+3JGX4cl2FiPV6ifjo1Xk2A==}
+  '@contextio/core@0.3.2':
+    resolution: {integrity: sha512-VHYCVmRu5naCzrs1quz7Bj0/mRn5Rm51w7aHNEtpOTfJpdkuRIRCenu+LuaQj6yFifb40MJ+ZZkKKJduOE9VgA==}
 
-  '@contextio/core@0.3.1':
-    resolution: {integrity: sha512-mITEMs5upUMNiQF4QJRRTg8L10VoS8LjRkDd37ZtLOf65PRlfKcpkjxgAGoapi4ve5j2mt2nEQbpHHOthwnYGw==}
-
-  '@contextio/proxy@0.2.3':
-    resolution: {integrity: sha512-u5/SrkHtTvSb0v/0oNOX2AP3e6O5VScOTkXptdxIIUgLTQ8R7zeU9vXHu2MD4xcUHpLZsbzRwWvXetsLWD+0bQ==}
+  '@contextio/proxy@0.2.4':
+    resolution: {integrity: sha512-4aAJ34EN6DZUddlwqC1KahrKIStGzl9wkU+RL4GfEt+aYcyjr1KC9B8vRbXlcYEJh2QjmpwpsVUaVXQjHT6fJA==}
     hasBin: true
 
-  '@contextio/redact@0.3.0':
-    resolution: {integrity: sha512-gWH36r89/8daSFHindl2i0bCV6MgvJTWYJ8oZPbh221wDiqFxfWGz4FsERoAwCeOSl1loJyCSf8Tl45vt7K+Tg==}
+  '@contextio/redact@0.3.1':
+    resolution: {integrity: sha512-ESSi8poNTEOiG+m6r10588vVOKVY3+HaXDUKa5C8BZFakVfwUqGfbbOw/1CY4zTm3FABl4EOiL629Z4501vmLQ==}
 
   '@hono/node-server@1.19.9':
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
@@ -257,17 +254,15 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.4':
     optional: true
 
-  '@contextio/core@0.3.0': {}
+  '@contextio/core@0.3.2': {}
 
-  '@contextio/core@0.3.1': {}
-
-  '@contextio/proxy@0.2.3':
+  '@contextio/proxy@0.2.4':
     dependencies:
-      '@contextio/core': 0.3.0
+      '@contextio/core': 0.3.2
 
-  '@contextio/redact@0.3.0':
+  '@contextio/redact@0.3.1':
     dependencies:
-      '@contextio/core': 0.3.0
+      '@contextio/core': 0.3.2
 
   '@hono/node-server@1.19.9(hono@4.11.9)':
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -165,6 +165,7 @@ if (parsedArgs.commandName === "analyze") {
         https_proxy: mitmConfig.proxyUrl,
         NPM_CONFIG_HTTPS_PROXY: mitmConfig.proxyUrl,
         WSS_PROXY: mitmConfig.proxyUrl,
+        NODE_USE_ENV_PROXY: "1",
 
         //these are all filled in with the CA cert path
         SSL_CERT_FILE: "[CA_CERT_PATH]",


### PR DESCRIPTION
Cherry-picked from #48 and rebased on current main.\n\nIncludes:\n- Copilot /responses capture patterns in mitm_addon.py\n- NODE_USE_ENV_PROXY=1 in mitm mode env in src/cli.ts\n- trailing whitespace cleanup\n\nValidation on this branch:\n- tsc passes\n- pnpm test passes