### PR TITLE
When launching pi, add providers based on env. vars & auth.json

### DIFF
--- a/src/cli-utils.ts
+++ b/src/cli-utils.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -426,4 +427,64 @@ export function getMitmConfig(): MitmConfig {
     lensSource: config.mitm.lensSource,
     lensSessionId: config.mitm.lensSessionId,
   };
+}
+
+// copied from https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/env-api-keys.ts
+const piEnvMap: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  "azure-openai-responses": "AZURE_OPENAI_API_KEY",
+  deepseek: "DEEPSEEK_API_KEY",
+  google: "GEMINI_API_KEY",
+  "google-vertex": "GOOGLE_CLOUD_API_KEY",
+  groq: "GROQ_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  xai: "XAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+  zai: "ZAI_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  "minimax-cn": "MINIMAX_CN_API_KEY",
+  moonshotai: "MOONSHOT_API_KEY",
+  "moonshotai-cn": "MOONSHOT_API_KEY",
+  huggingface: "HF_TOKEN",
+  fireworks: "FIREWORKS_API_KEY",
+  opencode: "OPENCODE_API_KEY",
+  "opencode-go": "OPENCODE_API_KEY",
+  "kimi-coding": "KIMI_API_KEY",
+  "cloudflare-workers-ai": "CLOUDFLARE_API_KEY",
+  "cloudflare-ai-gateway": "CLOUDFLARE_API_KEY",
+  xiaomi: "XIAOMI_API_KEY",
+  "xiaomi-token-plan-cn": "XIAOMI_TOKEN_PLAN_CN_API_KEY",
+  "xiaomi-token-plan-ams": "XIAOMI_TOKEN_PLAN_AMS_API_KEY",
+  "xiaomi-token-plan-sgp": "XIAOMI_TOKEN_PLAN_SGP_API_KEY",
+};
+
+export function addProvidersBasedOnAuthJson(
+  authConfig: Record<string, unknown>,
+  proxyBaseUrl: string,
+  providers: { [x: string]: unknown },
+) {
+  if (authConfig && typeof authConfig === "object") {
+    for (const providerName in Object.keys(authConfig)) {
+      if (!Object.hasOwn(providers, providerName)) {
+        providers[providerName] = { baseUrl: proxyBaseUrl };
+      }
+    }
+  }
+}
+
+export function addProvidersBasedOnEnvVars(
+  envDictionary: Record<string, string | undefined>,
+  proxyBaseUrl: string,
+  providers: { [x: string]: unknown },
+) {
+  for (const [providerName, envVarName] of Object.entries(piEnvMap)) {
+    if (
+      Object.hasOwn(envDictionary, envVarName) &&
+      !Object.hasOwn(providers, providerName)
+    ) {
+      providers[providerName] = { baseUrl: proxyBaseUrl };
+    }
+  }
 }

--- a/src/cli-utils.ts
+++ b/src/cli-utils.ts
@@ -466,7 +466,7 @@ export function addProvidersBasedOnAuthJson(
   providers: { [x: string]: unknown },
 ) {
   if (authConfig && typeof authConfig === "object") {
-    for (const providerName in Object.keys(authConfig)) {
+    for (const providerName of Object.keys(authConfig)) {
       if (!Object.hasOwn(providers, providerName)) {
         providers[providerName] = { baseUrl: proxyBaseUrl };
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,8 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  addProvidersBasedOnAuthJson,
+  addProvidersBasedOnEnvVars,
   CLI_CONSTANTS,
   formatHelpText,
   getMitmConfig,
@@ -22,37 +24,6 @@ import { VERSION } from "./version.generated.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-
-// copied from https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/env-api-keys.ts
-const piEnvMap: Record<string, string> = {
-  openai: "OPENAI_API_KEY",
-  "azure-openai-responses": "AZURE_OPENAI_API_KEY",
-  deepseek: "DEEPSEEK_API_KEY",
-  google: "GEMINI_API_KEY",
-  "google-vertex": "GOOGLE_CLOUD_API_KEY",
-  groq: "GROQ_API_KEY",
-  cerebras: "CEREBRAS_API_KEY",
-  xai: "XAI_API_KEY",
-  openrouter: "OPENROUTER_API_KEY",
-  "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
-  zai: "ZAI_API_KEY",
-  mistral: "MISTRAL_API_KEY",
-  minimax: "MINIMAX_API_KEY",
-  "minimax-cn": "MINIMAX_CN_API_KEY",
-  moonshotai: "MOONSHOT_API_KEY",
-  "moonshotai-cn": "MOONSHOT_API_KEY",
-  huggingface: "HF_TOKEN",
-  fireworks: "FIREWORKS_API_KEY",
-  opencode: "OPENCODE_API_KEY",
-  "opencode-go": "OPENCODE_API_KEY",
-  "kimi-coding": "KIMI_API_KEY",
-  "cloudflare-workers-ai": "CLOUDFLARE_API_KEY",
-  "cloudflare-ai-gateway": "CLOUDFLARE_API_KEY",
-  xiaomi: "XIAOMI_API_KEY",
-  "xiaomi-token-plan-cn": "XIAOMI_TOKEN_PLAN_CN_API_KEY",
-  "xiaomi-token-plan-ams": "XIAOMI_TOKEN_PLAN_AMS_API_KEY",
-  "xiaomi-token-plan-sgp": "XIAOMI_TOKEN_PLAN_SGP_API_KEY",
-};
 
 // Known tool config: env vars for the child process, extra CLI args, server env vars, and whether mitmproxy is needed
 // Note: actual tool config lives in cli-utils.ts so it can be unit-tested without importing this entrypoint.
@@ -873,7 +844,6 @@ if (parsedArgs.commandName === "analyze") {
         "https://us-central1-aiplatform.googleapis.com",
       ]);
 
-      // Add providers based on auth.json
       const authJsonPath = join(sourceDir, "auth.json");
       if (fs.existsSync(authJsonPath)) {
         let authConfig: Record<string, unknown> = {};
@@ -884,24 +854,10 @@ if (parsedArgs.commandName === "analyze") {
             "Warning: ~/.pi/agent/auth.json is not valid JSON; ignoring",
           );
         }
-        if (authConfig && typeof authConfig === "object") {
-          for (const providerName in Object.keys(authConfig)) {
-            if (!Object.hasOwn(providers, providerName)) {
-              providers[providerName] = { baseUrl: proxyBaseUrl };
-            }
-          }
-        }
+        addProvidersBasedOnAuthJson(authConfig, proxyBaseUrl, providers);
       }
 
-      // Add providers based on env. vars
-      for (const [providerName, envVarName] of Object.entries(piEnvMap)) {
-        if (
-          Object.hasOwn(process.env, envVarName) &&
-          !Object.hasOwn(providers, providerName)
-        ) {
-          providers[providerName] = { baseUrl: proxyBaseUrl };
-        }
-      }
+      addProvidersBasedOnEnvVars(process.env, proxyBaseUrl, providers);
 
       // Rewrite every provider that has an external baseUrl, regardless of its
       // key name. For providers whose upstream isn't natively known to the proxy,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,37 @@ import { VERSION } from "./version.generated.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// copied from https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/env-api-keys.ts
+const piEnvMap: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  "azure-openai-responses": "AZURE_OPENAI_API_KEY",
+  deepseek: "DEEPSEEK_API_KEY",
+  google: "GEMINI_API_KEY",
+  "google-vertex": "GOOGLE_CLOUD_API_KEY",
+  groq: "GROQ_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  xai: "XAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
+  "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+  zai: "ZAI_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  "minimax-cn": "MINIMAX_CN_API_KEY",
+  moonshotai: "MOONSHOT_API_KEY",
+  "moonshotai-cn": "MOONSHOT_API_KEY",
+  huggingface: "HF_TOKEN",
+  fireworks: "FIREWORKS_API_KEY",
+  opencode: "OPENCODE_API_KEY",
+  "opencode-go": "OPENCODE_API_KEY",
+  "kimi-coding": "KIMI_API_KEY",
+  "cloudflare-workers-ai": "CLOUDFLARE_API_KEY",
+  "cloudflare-ai-gateway": "CLOUDFLARE_API_KEY",
+  xiaomi: "XIAOMI_API_KEY",
+  "xiaomi-token-plan-cn": "XIAOMI_TOKEN_PLAN_CN_API_KEY",
+  "xiaomi-token-plan-ams": "XIAOMI_TOKEN_PLAN_AMS_API_KEY",
+  "xiaomi-token-plan-sgp": "XIAOMI_TOKEN_PLAN_SGP_API_KEY",
+};
+
 // Known tool config: env vars for the child process, extra CLI args, server env vars, and whether mitmproxy is needed
 // Note: actual tool config lives in cli-utils.ts so it can be unit-tested without importing this entrypoint.
 
@@ -841,6 +872,36 @@ if (parsedArgs.commandName === "analyze") {
         "https://cloudcode-pa.googleapis.com",
         "https://us-central1-aiplatform.googleapis.com",
       ]);
+
+      // Add providers based on auth.json
+      const authJsonPath = join(sourceDir, "auth.json");
+      if (fs.existsSync(authJsonPath)) {
+        let authConfig: Record<string, unknown> = {};
+        try {
+          authConfig = JSON.parse(fs.readFileSync(authJsonPath, "utf8"));
+        } catch {
+          console.error(
+            "Warning: ~/.pi/agent/auth.json is not valid JSON; ignoring",
+          );
+        }
+        if (authConfig && typeof authConfig === "object") {
+          for (const providerName in Object.keys(authConfig)) {
+            if (!Object.hasOwn(providers, providerName)) {
+              providers[providerName] = { baseUrl: proxyBaseUrl };
+            }
+          }
+        }
+      }
+
+      // Add providers based on env. vars
+      for (const [providerName, envVarName] of Object.entries(piEnvMap)) {
+        if (
+          Object.hasOwn(process.env, envVarName) &&
+          !Object.hasOwn(providers, providerName)
+        ) {
+          providers[providerName] = { baseUrl: proxyBaseUrl };
+        }
+      }
 
       // Rewrite every provider that has an external baseUrl, regardless of its
       // key name. For providers whose upstream isn't natively known to the proxy,

--- a/test/cli-utils.test.ts
+++ b/test/cli-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   addProvidersBasedOnAuthJson,
+  addProvidersBasedOnEnvVars,
   CLI_CONSTANTS,
   formatHelpText,
   getMitmConfig,
@@ -133,6 +134,17 @@ describe("cli-utils", () => {
     const expectedProvidersValue = {
       foo: { baseUrl: proxyBaseUrl },
       bar: { baseUrl: proxyBaseUrl },
+    };
+    assert.deepEqual(providers, expectedProvidersValue);
+  });
+
+  it("addProvidersBasedOnEnvVars", () => {
+    const sampleEnvVars = { FOO: "FOO", OPENROUTER_API_KEY: "BAR" };
+    const proxyBaseUrl = "localhost";
+    const providers = {};
+    addProvidersBasedOnEnvVars(sampleEnvVars, proxyBaseUrl, providers);
+    const expectedProvidersValue = {
+      openrouter: { baseUrl: proxyBaseUrl },
     };
     assert.deepEqual(providers, expectedProvidersValue);
   });

--- a/test/cli-utils.test.ts
+++ b/test/cli-utils.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  addProvidersBasedOnAuthJson,
   CLI_CONSTANTS,
   formatHelpText,
   getMitmConfig,
@@ -122,5 +123,17 @@ describe("cli-utils", () => {
     assert.equal(mitm.lensSource, "commandName");
     assert.equal(mitm.lensSessionId, "random");
     assert.ok(mitm.addonPath.endsWith("mitm_addon.py"));
+  });
+
+  it("addProvidersBasedOnAuthJson", () => {
+    const sampleAuthConfig = { foo: {}, bar: {} };
+    const proxyBaseUrl = "localhost";
+    const providers = {};
+    addProvidersBasedOnAuthJson(sampleAuthConfig, proxyBaseUrl, providers);
+    const expectedProvidersValue = {
+      foo: { baseUrl: proxyBaseUrl },
+      bar: { baseUrl: proxyBaseUrl },
+    };
+    assert.deepEqual(providers, expectedProvidersValue);
   });
 });


### PR DESCRIPTION
Add provider configs to models.json in temp dir used by pi based on defined env. vars & records in auth.json file.

Fixes https://github.com/larsderidder/context-lens/issues/55