### PR TITLE
fix(routing): align Codex paths with contextio

### DIFF
--- a/src/core/routing.ts
+++ b/src/core/routing.ts
@@ -24,6 +24,7 @@ export const API_PATH_SEGMENTS = new Set([
   "embeddings",
   "backend-api",
   "api",
+  "codex",
 ]);
 
 /**
@@ -57,8 +58,8 @@ export function classifyRequest(
   pathname: string,
   headers: Record<string, string | undefined>,
 ): { provider: Provider; apiFormat: ApiFormat } {
-  // ChatGPT backend traffic (Codex subscription)
-  if (pathname.match(/^\/(api|backend-api)\//))
+  // ChatGPT backend traffic. /codex/ is used by Pi's openai-codex provider.
+  if (pathname.match(/^\/(api|backend-api|codex)\//))
     return { provider: "chatgpt", apiFormat: "chatgpt-backend" };
 
   // Anthropic Messages API
@@ -164,7 +165,10 @@ export function resolveTargetUrl(
   let targetUrl = headers["x-target-url"];
   if (!targetUrl) {
     if (provider === "chatgpt") {
-      targetUrl = upstreams.chatgpt + parsedUrl.pathname + search;
+      const chatgptPath = parsedUrl.pathname.match(/^\/(api|backend-api)\//)
+        ? parsedUrl.pathname
+        : `/backend-api${parsedUrl.pathname}`;
+      targetUrl = upstreams.chatgpt + chatgptPath + search;
     } else if (provider === "anthropic") {
       targetUrl = upstreams.anthropic + parsedUrl.pathname + search;
     } else if (provider === "gemini") {

--- a/test/contextio-routing-contract.test.ts
+++ b/test/contextio-routing-contract.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  classifyRequest as classifyContextioRequest,
+  extractSource as extractContextioSource,
+  resolveTargetUrl as resolveContextioTargetUrl,
+  type Upstreams,
+} from "@contextio/core";
+
+import {
+  classifyRequest as classifyLensRequest,
+  extractSource as extractLensSource,
+  resolveTargetUrl as resolveLensTargetUrl,
+} from "../src/core/routing.js";
+
+const upstreams: Upstreams = {
+  openai: "https://api.openai.com",
+  anthropic: "https://api.anthropic.com",
+  chatgpt: "https://chatgpt.com",
+  gemini: "https://generativelanguage.googleapis.com",
+  geminiCodeAssist: "https://cloudcode-assist.googleusercontent.com",
+  vertex: "https://us-central1-aiplatform.googleapis.com",
+};
+
+const classificationCases = [
+  {
+    name: "Anthropic messages",
+    pathname: "/v1/messages",
+    headers: {},
+  },
+  {
+    name: "OpenAI responses",
+    pathname: "/v1/responses",
+    headers: {},
+  },
+  {
+    name: "ChatGPT backend Codex",
+    pathname: "/backend-api/codex/responses",
+    headers: {},
+  },
+  {
+    name: "Pi openai-codex backend path",
+    pathname: "/codex/responses",
+    headers: {},
+  },
+  {
+    name: "Gemini generateContent",
+    pathname: "/v1beta/models/gemini-pro:generateContent",
+    headers: {},
+  },
+  {
+    name: "Vertex regional Gemini",
+    pathname:
+      "/v1/projects/my-project/locations/europe-west4/publishers/google/models/gemini-pro:generateContent",
+    headers: {},
+  },
+];
+
+const sourceCases = [
+  "/claude/ab12cd34/v1/messages",
+  "/gemini/abcdef01/v1beta/models/pro:generateContent",
+  "/backend-api/codex/responses",
+  "/codex/responses",
+  "/v1/messages",
+];
+
+const resolutionCases = [
+  { pathname: "/v1/messages", search: "" },
+  { pathname: "/v1/responses", search: "" },
+  { pathname: "/responses", search: "" },
+  { pathname: "/backend-api/codex/responses", search: "" },
+  { pathname: "/codex/responses", search: "" },
+  {
+    pathname:
+      "/v1/projects/my-project/locations/europe-west4/publishers/google/models/gemini-pro:generateContent",
+    search: "?alt=sse",
+  },
+];
+
+describe("contextio routing contract", () => {
+  for (const { name, pathname, headers } of classificationCases) {
+    it(`classifies ${name} the same way`, () => {
+      assert.deepEqual(
+        classifyLensRequest(pathname, headers),
+        classifyContextioRequest(pathname, headers),
+      );
+    });
+  }
+
+  for (const pathname of sourceCases) {
+    it(`extracts source for ${pathname} the same way`, () => {
+      assert.deepEqual(
+        extractLensSource(pathname),
+        extractContextioSource(pathname),
+      );
+    });
+  }
+
+  for (const { pathname, search } of resolutionCases) {
+    it(`resolves ${pathname}${search} the same way`, () => {
+      assert.deepEqual(
+        resolveLensTargetUrl({ pathname, search }, {}, upstreams),
+        resolveContextioTargetUrl(pathname, search, {}, upstreams),
+      );
+    });
+  }
+});


### PR DESCRIPTION
Align Context Lens routing with @contextio/core for Pi openai-codex paths and add a routing contract test.