### PR TITLE
fix(cli): use platform temp paths

### DIFF
--- a/src/cli-utils.ts
+++ b/src/cli-utils.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -18,8 +19,8 @@ const PROXY_URL = `http://localhost:${PROXY_PORT}`;
 const UI_PORT = Number.isNaN(config.ui.port) ? 4041 : config.ui.port;
 const UI_URL = `http://localhost:${UI_PORT}`;
 
-const PI_AGENT_DIR_PREFIX = "/tmp/context-lens-pi-agent-";
-const BRYTI_DATA_DIR_PREFIX = "/tmp/context-lens-bryti-";
+const PI_AGENT_DIR_PREFIX = join(tmpdir(), "context-lens-pi-agent-");
+const BRYTI_DATA_DIR_PREFIX = join(tmpdir(), "context-lens-bryti-");
 const COMMAND_ALIASES: Record<string, string> = {
   cc: "claude",
   cx: "codex",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ function resolveLensSessionId(setting: string): string {
   if (setting === "none") return "";
   return setting; // fixed string
 }
-const LOCKFILE = "/tmp/context-lens.lock";
+const LOCKFILE = join(tmpdir(), "context-lens.lock");
 
 const rawArgs = process.argv.slice(2);
 const parsedArgs = parseCliArgs(rawArgs);

--- a/test/cli-utils.test.ts
+++ b/test/cli-utils.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, it } from "node:test";
 
 import {
@@ -34,7 +36,6 @@ describe("cli-utils", () => {
     );
 
     const codex = getToolConfig("codex");
-    const mitmCfg = getMitmConfig();
     assert.equal(codex.needsMitm, true);
     assert.deepEqual(codex.childEnv, {});
     assert.deepEqual(codex.extraArgs, []);
@@ -44,6 +45,16 @@ describe("cli-utils", () => {
     assert.equal(
       pi.childEnv.PI_CODING_AGENT_DIR,
       CLI_CONSTANTS.PI_AGENT_DIR_PREFIX,
+    );
+    assert.equal(
+      CLI_CONSTANTS.PI_AGENT_DIR_PREFIX,
+      path.join(tmpdir(), "context-lens-pi-agent-"),
+    );
+
+    const bryti = getToolConfig("bryti");
+    assert.equal(
+      bryti.childEnv.BRYTI_DATA_DIR,
+      path.join(tmpdir(), "context-lens-bryti-"),
     );
   });
 


### PR DESCRIPTION
Fixes #62.

Uses os.tmpdir() for CLI temp paths instead of hardcoded /tmp, covering:
- Pi temp agent directory
- Bryti temp data directory
- CLI lockfile path

This avoids Windows crashes when /tmp does not exist.